### PR TITLE
Fix warning about always empty value

### DIFF
--- a/lib/P1Client.js
+++ b/lib/P1Client.js
@@ -444,7 +444,7 @@ class P1Client extends EventEmitter {
           continue
         }
         for (const id in a) {
-          if (a[id].key != null) {
+          if (a[id].key != null && values[id] !== '()') {
             try {
               obj[a[id].key] = a[id].f(a[id].allValues ? values : values[id])
             } catch (error) {


### PR DESCRIPTION
P1 on my slimme meter is always complaining 

`[P1] warning: 1-0:99.97.0: ignoring unknown value ()`

With this simple patch it isn't anymore.